### PR TITLE
build: upgrade to Java 25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 		<junit.version>6.1.0</junit.version>
 		<spotbugs.version>4.8.3</spotbugs.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.release>21</maven.compiler.release>
+		<maven.compiler.release>25</maven.compiler.release>
 		<gpg.skip>true</gpg.skip>
 	</properties>
 
@@ -288,7 +288,7 @@
 									<version>3.8</version>
 								</requireMavenVersion>
 								<requireJavaVersion>
-									<version>21</version>
+									<version>25</version>
 								</requireJavaVersion>
 							</rules>
 						</configuration>


### PR DESCRIPTION
Raise maven.compiler.release and the enforcer requireJavaVersion rule from 21 to 25. The build plugins are already recent enough for Java 25, so no plugin version changes are required. The full build (compile, tests, JaCoCo, Spotless, SpotBugs, PMD) passes on Java 25.